### PR TITLE
Make volume settings work in openal.

### DIFF
--- a/Code/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioManager.cpp
+++ b/Code/GameEngineDevice/Source/OpenALAudioDevice/OpenALAudioManager.cpp
@@ -1236,20 +1236,18 @@ void OpenALAudioManager::closeAnySamplesUsingFile(const void* fileToClose)
 void OpenALAudioManager::adjustPlayingVolume(OpenALPlayingAudio* audio)
 {
 	Real desiredVolume = audio->m_audioEventRTS->getVolume() * audio->m_audioEventRTS->getVolumeShift();
-	if (audio->m_type == PAT_Sample) {
-		alSourcef(audio->source, AL_GAIN, m_soundVolume * desiredVolume);
-	}
-	else if (audio->m_type == PAT_3DSample) {
-		alSourcef(audio->source, AL_GAIN, m_sound3DVolume * desiredVolume);
-	}
-	else if (audio->m_type == PAT_Stream) {
-		if (audio->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			alSourcef(audio->source, AL_GAIN, m_sound3DVolume * m_musicVolume * desiredVolume);
-		}
-		else {
-			alSourcef(audio->source, AL_GAIN, m_sound3DVolume * m_speechVolume * desiredVolume);
-		}
-	}
+	AudioType at = audio->m_audioEventRTS->getAudioEventInfo()->m_soundType;
+	Bool isPositionalAudio = audio->m_audioEventRTS->isPositionalAudio();
+
+	if (isPositionalAudio)
+		desiredVolume *= m_sound3DVolume;
+	else if (at == AT_Music)
+		desiredVolume *= m_musicVolume;
+	else if (at == AT_Streaming)
+		desiredVolume *= m_speechVolume;
+	else // AT_SoundEffect and anything else
+		desiredVolume *= m_soundVolume;
+	alSourcef(audio->source, AL_GAIN, desiredVolume);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Code/GameEngineDevice/Source/OpenALAudioDevice/OpenALDriver.cpp
+++ b/Code/GameEngineDevice/Source/OpenALAudioDevice/OpenALDriver.cpp
@@ -244,7 +244,9 @@ void OpenALAudioManager::playSample(AudioEventRTS* event, OpenALPlayingAudio* au
 
     ALuint source = 0;
 
-    if (isMusic)
+    AudioType at = event->getAudioEventInfo()->m_soundType;
+
+    if (at == AT_Music)
     {
         // Always use the dedicated music source
         source = m_musicSource;
@@ -269,11 +271,17 @@ void OpenALAudioManager::playSample(AudioEventRTS* event, OpenALPlayingAudio* au
     alSourcei(source, AL_BUFFER, buffer);
     alSourcei(source, AL_SOURCE_RELATIVE, AL_TRUE);
     alSource3f(source, AL_POSITION, 0.0f, 0.0f, 0.0f);
-    Real volume = event->getVolume();
+    Real volume = event->getVolume() * event->getVolumeShift();
+    if (at == AT_Music)
+        volume *= m_musicVolume;
+    else if (at == AT_Streaming)
+        volume *= m_speechVolume;
+    else // AT_SoundEffect and anything else
+        volume *= m_soundVolume;
     alSourcef(source, AL_GAIN, volume);
 
     // If this is music, you might want to loop it
-    if (isMusic)
+    if (at == AT_Music)
     {
         alSourcei(source, AL_LOOPING, AL_TRUE);
     }
@@ -313,7 +321,7 @@ bool OpenALAudioManager::playSample3D(AudioEventRTS* event, OpenALPlayingAudio* 
 
     // Set 3D position and volume
     alSource3f(source, AL_POSITION, pos->x, pos->y, pos->z);
-    Real volume = event->getVolume();
+    Real volume = event->getVolume() * event->getVolumeShift() * m_sound3DVolume;
     alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
     alSourcef(source, AL_GAIN, volume);
     alSourcef(source, AL_REFERENCE_DISTANCE, event->getAudioEventInfo()->m_minDistance);


### PR DESCRIPTION
This makes audio volume settings in the game work -also I think it fixes some weird  noises but might be completely just my setup-.

I am not sure if this is the correct way to calculate the volume (original did `m_sound3DVolume * m_speechVolume * desiredVolume` while this does `desiredVolume *= m_speechVolume`) but when I let it be like the original it seams to be broken.

also `isMusic` is not used in `OpenALAudioManager::playSample(...)`  anymore, it can be removed.