### PR TITLE
build: replaced GameEngineDebug_x64.lib with GameEngineDebug project

### DIFF
--- a/Code/GameEngine/GameEngine.vcxproj
+++ b/Code/GameEngine/GameEngine.vcxproj
@@ -80,7 +80,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>Lib/GameEngineDebug_x64.lib</OutputFile>
+      <OutputFile>Lib/GameEngineDebug.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
     <Bscmake>


### PR DESCRIPTION
After a fresh pull, the RTS build failed due to a linking error to GameEngineDebug_x64.lib. This changes fixes it