### PR TITLE
Undo changes in UnicodeString::set and properly stop OOB reads in HotKeyTranslator

### DIFF
--- a/Code/GameEngine/Include/Common/UnicodeString.h
+++ b/Code/GameEngine/Include/Common/UnicodeString.h
@@ -199,9 +199,9 @@ public:
 		Replace the contents of self with the given string.
 		Note that a copy of the string is made; the input ptr is not saved.
 	*/
-	void set(const WideChar* s, int len = -1);
+	void set(const WideChar* s);
 
-	void set(const UnsignedShort* s, int len = -1);
+	void set(const UnsignedShort* s);
 
 	/**
 		replace contents of self with the given string. Note the

--- a/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -168,12 +168,12 @@ void UnicodeString::set(const UnicodeString& stringSrc)
 }
 
 // -----------------------------------------------------
-void UnicodeString::set(const WideChar* s, int len)
+void UnicodeString::set(const WideChar* s)
 {
 	validate();
 	if (!m_data || s != peek())
 	{
-		len = s ? wcslen(s) : 0;
+		int len = s ? wcslen(s) : 0;
 		if (len)
 		{
 			ensureUniqueBufferOfSize(len + 1, false, s, NULL);
@@ -186,12 +186,12 @@ void UnicodeString::set(const WideChar* s, int len)
 	validate();
 }
 
-void UnicodeString::set(const UnsignedShort* s1, int len) {
+void UnicodeString::set(const UnsignedShort* s1) {
 	validate();
 	const WideChar* s = (const WideChar* )s1;
 	if (!m_data || s != peek())
 	{
-		len = s ? wcslen(s) : 0;
+		int len = s ? wcslen(s) : 0;
 		if (len)
 		{
 			ensureUniqueBufferOfSize(len + 1, false, s, NULL);

--- a/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
+++ b/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
@@ -98,9 +98,9 @@ GameMessageDisposition HotKeyTranslator::translateGameMessage(const GameMessage 
 		}
 		if(newModState != 0)
 			return disp;
-		WideChar key = TheKeyboard->getPrintableKey(msg->getArgument(0)->integer, 0);
+		WideChar key[2] = { TheKeyboard->getPrintableKey(msg->getArgument(0)->integer, 0), 0 };
 		UnicodeString uKey;
-		uKey.set(&key, 1);
+		uKey.set(key);
 		AsciiString aKey;
 		aKey.translate(uKey);
 		if(TheHotKeyManager && TheHotKeyManager->executeHotKey(aKey))


### PR DESCRIPTION
This PR completely undoes the changes I made in `UnicodeString::set` in favor of simply zero-terminating the key character in the `HotKeyTranslator` class.