### PR TITLE
Cmake cleanup

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -4,6 +4,107 @@ project(RTS LANGUAGES C CXX)
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Internal;Release" CACHE STRING "Configs" FORCE)
 
+################################################################################
+# SETUP
+################################################################################
+
+##### AUTOMATED #####
+
+set(GNG_COMPILE_OPTIONS "")
+set(GNG_LINK_OPTIONS "")
+set(GNG_COMPILE_DEFINITIONS "")
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(GNG_DEBUG TRUE)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Internal")
+    set(GNG_INTERNAL TRUE)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(GNG_RELEASE TRUE)
+endif()
+
+##### Compiler & Linker Settings #####
+
+# Microsoft Visual C/C++ Compiler
+if(MSVC)
+
+    ##### Common #####
+
+    set(GNG_COMPILE_OPTIONS
+        /nologo # Hide compiler copyright notice
+        /W1     # Warnings level 1 (TODO Increase it as we fix such warnnings)
+    )
+    set(GNG_LINK_OPTIONS
+        /NOLOGO # Hide linker copyright notice
+    )
+    set(GNG_COMPILE_DEFINITIONS
+        __PLACEMENT_VEC_NEW_INLINE # Hack for placement new overides (will be removed)
+        _WINDOWS
+        WINVER=0x0A00              # Windows 10 is the minimum as we use DX12
+        _WIN32_WINNT=0x0A00        # Windows 10 is the minimum as we use DX12
+
+        _CRT_SECURE_NO_WARNINGS
+        _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
+    )
+
+    ##### Debug #####
+
+    if(GNG_DEBUG)
+        list(APPEND GNG_COMPILE_OPTIONS
+            /Od   # Disable optimizations
+            /MDd  # MultiThreaded Debug DLL Runtime
+            /Zi   # Generate Debug Database (.pdb)
+            /RTC1 # Runtime Error Checking
+        )
+        list(APPEND GNG_LINK_OPTIONS
+            /DEBUG
+        )
+        list(APPEND GNG_COMPILE_DEFINITIONS
+            _DEBUG
+        )
+
+    ##### Internal #####
+
+    elseif(GNG_INTERNAL)
+        list(APPEND GNG_COMPILE_OPTIONS
+            /O2 # Favor speed over size
+            /MD # MultiThreaded DLL Runtime
+            /Zi # Generate Debug Database (.pdb)
+            /Gy # Enable Function level linking
+        )
+        list(APPEND GNG_LINK_OPTIONS
+            /DEBUG
+        )
+        list(APPEND GNG_COMPILE_DEFINITIONS
+            _INTERNAL
+            NDEBUG
+        )
+
+    ##### Release #####
+
+    elseif(GNG_RELEASE)
+        list(APPEND GNG_COMPILE_OPTIONS
+            /O2 # Favor speed over size
+            /MD # MultiThreaded DLL Runtime
+            /Gy # Enable Function level linking
+        )
+        list(APPEND GNG_LINK_OPTIONS
+
+        )
+        list(APPEND GNG_COMPILE_DEFINITIONS
+            _RELEASE
+            NDEBUG
+            IG_DEBUG_STACKTRACE
+            WIN32
+        )
+    endif()
+endif()
+
+################################################################################
+
 add_subdirectory(GameEngine)
 add_subdirectory(GameEngineDevice)
 add_subdirectory(GameRenderer)
@@ -82,46 +183,16 @@ target_include_directories(RTS PRIVATE
 )
 
 target_compile_definitions(RTS PRIVATE
-    __PLACEMENT_VEC_NEW_INLINE
-    _WINDOWS
-
-    # Debug
-    $<$<CONFIG:Debug>:_DEBUG>
-    $<$<CONFIG:Debug>:BROWSER_DEBUG>
-
-    # Release
-    $<$<CONFIG:Release>:_RELEASE>
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Release>:_DISABLE_VECTOR_ANNOTATION>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
-    $<$<CONFIG:Release>:WIN32>
-
-    # Internal
-    $<$<CONFIG:Internal>:_INTERNAL>
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Internal>:_DISABLE_VECTOR_ANNOTATION>
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
-if(MSVC)
-    target_compile_options(RTS PRIVATE
-        # Debug config: no optimization, debug runtime
-        $<$<CONFIG:Debug>:/Od>
-        $<$<CONFIG:Debug>:/MDd>
+target_compile_options(RTS PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
 
-        # Release config: optimize, release runtime
-        $<$<CONFIG:Release>:/O2>
-        $<$<CONFIG:Release>:/MD>
-
-        # Internal config: often “RelWithDebInfo”-style
-        $<$<CONFIG:Internal>:/O2>
-        $<$<CONFIG:Internal>:/MD>
-
-        # Common warnings level
-        /W3
-    )
-endif()
+target_link_options(RTS PRIVATE
+    ${GNG_LINK_OPTIONS}
+)
 
 target_link_libraries(RTS PRIVATE
     # Common Windows libs
@@ -146,12 +217,6 @@ target_link_libraries(RTS PRIVATE
     wsock32
     imm32
     wininet
-
-    # External Dependencies
-    OpenAL::OpenAL
-
-    # GameSpy SDK
-    UniSpySDK
 
     GameEngine
 )

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -29,6 +29,12 @@ set(ALSOFT_INSTALL_UTILS OFF)
 
 add_subdirectory(Libraries/OpenAL)
 
+set_target_properties(OpenAL PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../Run"
+
+    OUTPUT_NAME_DEBUG "OpenAL32_debug"
+)
+
 add_subdirectory(Libraries/Source/GameSpy)
  
 # Add the main executable; WIN32 for the Windows subsystem (no console).

--- a/Code/GameEngine/CMakeLists.txt
+++ b/Code/GameEngine/CMakeLists.txt
@@ -563,44 +563,21 @@ target_link_libraries(GameEngine PRIVATE
     wwlib
     WWDownload
     Compression
+
+    UniSpySDK
 )
 
 target_compile_definitions(GameEngine PRIVATE
-  _CRT_SECURE_NO_WARNINGS
-  _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
-  _LIB
-  _WINDOWS
-  Z_PREFIX
-
-  $<$<CONFIG:Debug>:
-    _DEBUG
-    BROWSER_DEBUG
-    _DISABLE_STRING_ANNOTATION
-    _DISABLE_VECTOR_ANNOTATION
-  >
-
-  $<$<CONFIG:Internal>:
-    NDEBUG
-    _INTERNAL
-    _DISABLE_STRING_ANNOTATION
-    _DISABLE_VECTOR_ANNOTATION
-  >
-
-  $<$<CONFIG:Release>:
-    IG_DEBUG_STACKTRACE
-    NDEBUG
-    _RELEASE
-    WIN32
-  >
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
-if (MSVC)
-    target_compile_options(GameEngine PRIVATE
-        $<$<CONFIG:Debug>:/Od /MDd /Zi>
-        $<$<CONFIG:Internal>:/O2 /Ob1 /MD /Zi /GF /Gy>
-        $<$<CONFIG:Release>:/O2 /Ob2 /MD /GF /Gy>
-    )
-endif()
+target_compile_options(GameEngine PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(GameEngine PRIVATE
+    ${GNG_LINK_OPTIONS}
+)
 
 #
 # 4) Precompiled header usage
@@ -622,7 +599,7 @@ endif()
 
 # DO NOT TOUCH THIS, CODE RELAYS ON IT BEING LIKE THIS
 set_target_properties(GameEngine PROPERTIES
-  OUTPUT_NAME_DEBUG      "GameEngineDebug"
-  OUTPUT_NAME_Internal   "GameEngineInternal"
-  OUTPUT_NAME_Release    "GameEngine"
+    OUTPUT_NAME_DEBUG      "GameEngineDebug"
+    OUTPUT_NAME_INTERNAL   "GameEngineInternal"
+    OUTPUT_NAME_RELEASE    "GameEngine"
 )

--- a/Code/GameEngine/Source/Console/Console.cpp
+++ b/Code/GameEngine/Source/Console/Console.cpp
@@ -13,6 +13,7 @@ static const char* VERSION_STRING = "Command and Conquer Generals Next-Gen v0.06
 Console::Console()
 	: ScrollToBottom(false)
 	, HistoryPos(-1)
+	, IsConsoleActive(false)
 {
 	ClearLog();
 	AddLog("Welcome to the Quake-Style Console!");

--- a/Code/GameEngine/Source/Console/Console.h
+++ b/Code/GameEngine/Source/Console/Console.h
@@ -17,6 +17,8 @@ public:
 	// Clear the entire log buffer.
 	void ClearLog();
 
+	bool                     IsConsoleActive;
+
 private:
 	static int  TextEditCallbackStub(ImGuiInputTextCallbackData* data);
 	int         TextEditCallback(ImGuiInputTextCallbackData* data);

--- a/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -81,6 +81,9 @@
 #include "GameLogic/GhostObject.h"
 #include "GameLogic/Object.h"
 #include "GameLogic/ScriptEngine.h"		// For TheScriptEngine - jkmcd
+
+#include "../Console/Console.h"
+
 #ifdef _INTERNAL
 // for occasional debugging...
 //#pragma optimize("", off)
@@ -714,8 +717,7 @@ void GameClient::update( void )
 	}
 
 	{
-		extern Bool IsConsoleActive;
-		if (IsConsoleActive)
+		if (DevConsole.IsConsoleActive)
 		{
 			DevConsole.Draw(0.5f);
 		}

--- a/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4606,7 +4606,6 @@ WWCONSOLE_COMMAND(disconnect, "Disconnects from a game and returns you to the ma
 
 WWCONSOLE_COMMAND(map, "Opens a map")
 {
-	extern Bool IsConsoleActive;
 	if (args.size() <= 0)
 	{
 		DevConsole.AddLog("Usage: open <mapname> e.g. open Maps/USA01/USA01.map");
@@ -4621,7 +4620,7 @@ WWCONSOLE_COMMAND(map, "Opens a map")
 
 	TheWritableGlobalData->m_mapName = AsciiString(args[0].c_str());
 	
-	IsConsoleActive = false;
+	DevConsole.IsConsoleActive = false;
 
 	if (TheGameLogic->isInGame())
 		TheGameLogic->clearGameData(FALSE);

--- a/Code/GameEngine/Source/Precompiled/PreRTS.h
+++ b/Code/GameEngine/Source/Precompiled/PreRTS.h
@@ -41,7 +41,7 @@ class STLSpecialAlloc;
 // PLEASE DO NOT ABUSE WINDOWS OR IT WILL BE REMOVED ENTIRELY. :-)
 //--------------------------------------------------------------------------------- System Includes 
 
-#define __PLACEMENT_VEC_NEW_INLINE // jmarshall
+//#define __PLACEMENT_VEC_NEW_INLINE // jmarshall
 #include <string.h>
 #include <atlbase.h>
 #include <windows.h>

--- a/Code/GameEngineDevice/CMakeLists.txt
+++ b/Code/GameEngineDevice/CMakeLists.txt
@@ -96,9 +96,6 @@ add_library(GameEngineDevice STATIC
     Source/Win32Device/GameClient/Win32Mouse.cpp
 )
 
-#------------------------------------------------------------------------------
-# Include paths
-#------------------------------------------------------------------------------
 target_include_directories(GameEngineDevice PRIVATE
     ../GameRenderer
     ../Libraries/OpenAL/include
@@ -119,45 +116,17 @@ target_include_directories(GameEngineDevice PRIVATE
 
 target_link_libraries(GameEngineDevice PRIVATE
     ww3d2
+    OpenAL
 )
 
-#------------------------------------------------------------------------------
-# Preprocessor definitions by configuration:
-#------------------------------------------------------------------------------
 target_compile_definitions(GameEngineDevice PRIVATE
-  __PLACEMENT_VEC_NEW_INLINE
-  _LIB
-  _WINDOWS
-
-  $<$<CONFIG:Debug>:_DEBUG>
-
-  $<$<CONFIG:Internal>:
-    NDEBUG
-    _INTERNAL
-    _DISABLE_STRING_ANNOTATION
-    _DISABLE_VECTOR_ANNOTATION
-  >
-
-  $<$<CONFIG:Release>:
-    IG_DEBUG_STACKTRACE
-    WIN32
-    NDEBUG
-    _RELEASE
-  >
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
-#------------------------------------------------------------------------------
-# Compiler and runtime library flags (typical MSVC settings):
-#------------------------------------------------------------------------------
 target_compile_options(GameEngineDevice PRIVATE
-  $<$<C_COMPILER_ID:MSVC>:
-    # Debug
-    $<$<CONFIG:Debug>:/Od /MDd /Zi /RTC1>
+    ${GNG_COMPILE_OPTIONS}
+)
 
-    # Internal
-    $<$<CONFIG:Internal>:/O2 /Ob1 /MD /Zi /GF /Gy>
-
-    # Release
-    $<$<CONFIG:Release>:/O2 /Ob2 /MD /GF /Gy>
-  >
+target_link_options(GameEngineDevice PRIVATE
+    ${GNG_LINK_OPTIONS}
 )

--- a/Code/GameRenderer/CMakeLists.txt
+++ b/Code/GameRenderer/CMakeLists.txt
@@ -55,52 +55,14 @@ target_include_directories(GameRenderer PRIVATE
 )
 
 target_compile_definitions(GameRenderer PRIVATE
-    __PLACEMENT_VEC_NEW_INLINE
-    _LIB
-    _WINDOWS
+    ${GNG_COMPILE_DEFINITIONS}
     WIN32_LEAN_AND_MEAN
 )
 
-# == Release ==
-target_compile_definitions(GameRenderer PRIVATE
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
+target_compile_options(GameRenderer PRIVATE
+    ${GNG_COMPILE_OPTIONS}
 )
 
-# == Debug ==
-target_compile_definitions(GameRenderer PRIVATE
-    $<$<CONFIG:Debug>:_DEBUG>
+target_link_options(GameRenderer PRIVATE
+    ${GNG_LINK_OPTIONS}
 )
-
-# == Internal ==
-target_compile_definitions(GameRenderer PRIVATE
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_INTERNAL>
-    $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Internal>:_DISABLE_VECTOR_ANNOTATION>
-)
-
-if(MSVC)
-    target_compile_options(GameRenderer PRIVATE
-        # Common flags
-        /W3
-        /nologo
-
-        # Debug
-        $<$<CONFIG:Debug>:/MDd>
-        $<$<CONFIG:Debug>:/Zi>
-        $<$<CONFIG:Debug>:/Ob1>        # "Only Explicit"
-
-        # Release
-        $<$<CONFIG:Release>:/MD>
-        $<$<CONFIG:Release>:/Zi>
-        $<$<CONFIG:Release>:/O2>
-        $<$<CONFIG:Release>:/Ob2>      # "Any Suitable"
-
-        # Internal
-        $<$<CONFIG:Internal>:/MD>
-        $<$<CONFIG:Internal>:/Zi>
-        $<$<CONFIG:Internal>:/O2>
-        $<$<CONFIG:Internal>:/Ob1>     # "Only Explicit Inline"
-    )
-endif()

--- a/Code/Libraries/Source/Compression/CMakeLists.txt
+++ b/Code/Libraries/Source/Compression/CMakeLists.txt
@@ -43,20 +43,13 @@ target_include_directories(Compression PRIVATE
 )
 
 target_compile_definitions(Compression PRIVATE
-  _CRT_SECURE_NO_WARNINGS
-
-  $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION>
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
 target_compile_options(Compression PRIVATE
-  $<$<C_COMPILER_ID:MSVC>:
-    # Debug => /Od (Optimization=Disabled), /MDd (MultiThreadedDebugDLL)
-    $<$<CONFIG:Debug>:/Od /MDd /RTC1 /Zi>
+    ${GNG_COMPILE_OPTIONS}
+)
 
-    # Internal => /O2 (MaxSpeed), /Ob1 (OnlyExplicitInline), /MD, string pooling => /GF, function-level link => /Gy
-    $<$<CONFIG:Internal>:/O2 /Ob1 /MD /GF /Gy>
-
-    # Release => /O2 (MaxSpeed), /Ob2 (AnySuitable), /MD, string pooling => /GF, function-level link => /Gy
-    $<$<CONFIG:Release>:/O2 /Ob2 /MD /GF /Gy>
-  >
+target_link_options(Compression PRIVATE
+    ${GNG_LINK_OPTIONS}
 )

--- a/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -143,18 +143,10 @@ target_link_libraries(ww3d2 PRIVATE
 )
 
 target_compile_definitions(ww3d2 PRIVATE
+    ${GNG_COMPILE_DEFINITIONS}
     WINDOWS_IGNORE_PACKING_MISMATCH
-    __PLACEMENT_VEC_NEW_INLINE
-    WINVER=0x400
-    _WINDOWS
-    WIN32_LEAN_AND_MEAN
+    WIN32_LEAN_AND_MEAN # Exclude some headers to speed up the build process
 
-    # Debug
-    $<$<CONFIG:Debug>:_DEBUG>
-    # Release
-    $<$<CONFIG:Release>:NDEBUG;WIN32;IG_DEBUG_STACKTRACE>
-    # Internal
-    $<$<CONFIG:Internal>:NDEBUG;_INTERNAL;_DISABLE_STRING_ANNOTATION;_DISABLE_VECTOR_ANNOTATION>
     # Profile
     $<$<CONFIG:Profile>:NDEBUG;WWDEBUG;WIN32>
     # DebugE
@@ -163,19 +155,10 @@ target_compile_definitions(ww3d2 PRIVATE
     $<$<CONFIG:ProfileE>:NDEBUG;WWDEBUG;WIN32;PARAM_EDITING_ON>
 )
 
-#
-# -- 8. (Optional) Extra MSVC compiler flags to match your .vcxproj settings:
-#    e.g., /O2 (MaxSpeed), /Ob2 (inline expansions), /GF (string pooling), /Gy, etc.
-#    You can replicate them with target_compile_options, e.g.:
-#
-# if(MSVC)
-#   target_compile_options(ww3d2 PRIVATE
-#       $<$<CONFIG:Debug>:/O2 /Ob2 /GF /Gy>
-#       $<$<CONFIG:Release>:/O2 /Ob2 /GF /Gy>
-#       $<$<CONFIG:Internal>:/O2 /Ob1 /GF /Gy>
-#       $<$<CONFIG:Profile>:/O2 /Ob2 /GF /Gy>
-#       $<$<CONFIG:DebugE>:/Od>
-#       $<$<CONFIG:ProfileE>:/O2 /Ob1 /GF /Gy>
-#       # etc...
-#   )
-# endif()
+target_compile_options(ww3d2 PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(ww3d2 PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
@@ -20,45 +20,24 @@ target_include_directories(WWDebug PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../wwlib"
 )
 
-target_link_libraries(WWDebug
-    PRIVATE
+target_link_libraries(WWDebug PRIVATE
     wwlib
 )
 
 target_compile_definitions(WWDebug PRIVATE
-    WINVER=0x400
-    _WINDOWS
+    ${GNG_COMPILE_DEFINITIONS}
     WIN32_LEAN_AND_MEAN
-
-    # Debug
-    $<$<CONFIG:Debug>:_DEBUG>
-
-    # Internal
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_INTERNAL>
 
     # Profile
     $<$<CONFIG:Profile>:NDEBUG>
     $<$<CONFIG:Profile>:WWDEBUG>
     $<$<CONFIG:Profile>:WIN32>
-
-    # Release
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:WIN32>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
 )
 
-#
-# (Optional) If you want to mimic MSVC-specific compiler switches like:
-#   /O2 (MaxSpeed), /Ob2 (inline any suitable), /GF (string pooling), /Gy (function-level linking),
-#   and treat warnings as errors (/WX), you can do something like:
-#
-# if(MSVC)
-#   target_compile_options(WWDebug PRIVATE
-#       "$<$<CONFIG:Debug>:/O2 /Ob2 /GF /Gy /WX>"
-#       "$<$<CONFIG:Internal>:/O2 /Ob1 /GF /Gy /WX>"
-#       "$<$<CONFIG:Profile>:/O2 /Ob2 /GF /Gy /WX>"
-#       "$<$<CONFIG:Release>:/O2 /Ob2 /GF /Gy /WX>"
-#   )
-# endif()
-#
+target_compile_options(WWDebug PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(WWDebug PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -15,38 +15,13 @@ target_include_directories(WWDownload PRIVATE
 )
 
 target_compile_definitions(WWDownload PRIVATE
-    _LIB
-
-    $<$<CONFIG:Debug>:_DEBUG>
-
-    $<$<CONFIG:Internal>:DEBUG>
-    $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Internal>:_DISABLE_VECTOR_ANNOTATION>
-
-    $<$<CONFIG:Release>:WIN32>
-    $<$<CONFIG:Release>:NDEBUG>
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
-if(MSVC)
-    target_compile_options(WWDownload PRIVATE
-        /W3
-        /Gy
+target_compile_options(WWDownload PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
 
-        # Debug => /Od + /MDd + basic runtime checks (/RTC1 or /RTCs)
-        $<$<CONFIG:Debug>:/Od>
-        $<$<CONFIG:Debug>:/MDd>
-        $<$<CONFIG:Debug>:/RTC1>
-
-        # Internal
-        #  (MaxSpeed => /O2, OnlyExplicitInline => /Ob1, MultiThreadedDLL => /MD)
-        $<$<CONFIG:Internal>:/O2>
-        $<$<CONFIG:Internal>:/Ob1>
-        $<$<CONFIG:Internal>:/MD>
-
-        # Release
-        #  (MaxSpeed => /O2, AnySuitable => /Ob2, MultiThreadedDLL => /MD)
-        $<$<CONFIG:Release>:/O2>
-        $<$<CONFIG:Release>:/Ob2>
-        $<$<CONFIG:Release>:/MD>
-    )
-endif()
+target_link_options(WWDownload PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -88,27 +88,10 @@ target_include_directories(wwlib PRIVATE
 )
 
 target_compile_definitions(wwlib PRIVATE
-    __PLACEMENT_VEC_NEW_INLINE
-    WINVER=0x400
-    _WINDOWS
+    ${GNG_COMPILE_DEFINITIONS}
     WIN32_LEAN_AND_MEAN
     REGEX_MALLOC
     STDC_HEADERS
-
-    # Debug:
-    $<$<CONFIG:Debug>:_DEBUG>
-
-    # Release:
-    $<$<CONFIG:Release>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Release>:_DISABLE_VECTOR_ANNOTATION>
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
-
-    # Internal:
-    $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Internal>:_DISABLE_VECTOR_ANNOTATION>
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_INTERNAL>
 
     # Profile:
     $<$<CONFIG:Profile>:NDEBUG>
@@ -116,3 +99,10 @@ target_compile_definitions(wwlib PRIVATE
     $<$<CONFIG:Profile>:WIN32>
 )
 
+target_compile_options(wwlib PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(wwlib PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
@@ -58,29 +58,23 @@ target_link_libraries(wwmath PRIVATE
 )
 
 target_compile_definitions(wwmath PRIVATE
-    WINVER=0x400
-    _WINDOWS
+    ${GNG_COMPILE_DEFINITIONS}
     WIN32_LEAN_AND_MEAN
 
     # Debug:
     $<$<CONFIG:Debug>:G_CODE_BASE>
     $<$<CONFIG:Debug>:DIRECTX>
-    $<$<CONFIG:Debug>:_DEBUG>
-
-    # Internal:
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_INTERNAL>
-    $<$<CONFIG:Internal>:_DISABLE_STRING_ANNOTATION>
-    $<$<CONFIG:Internal>:_DISABLE_VECTOR_ANNOTATION>
 
     # Profile:
     $<$<CONFIG:Profile>:NDEBUG>
     $<$<CONFIG:Profile>:WWDEBUG>
     $<$<CONFIG:Profile>:WIN32>
-
-    # Release:
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:WIN32>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
 )
 
+target_compile_options(wwmath PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(wwmath PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Libraries/Source/WWVegas/WWSaveLoad/CMakeLists.txt
+++ b/Code/Libraries/Source/WWVegas/WWSaveLoad/CMakeLists.txt
@@ -26,18 +26,12 @@ target_include_directories(wwsaveload PRIVATE
 )
 
 target_compile_definitions(wwsaveload PRIVATE
-    WINVER=0x400
-    _WINDOWS
-
-    $<$<CONFIG:Debug>:_DEBUG>
+    ${GNG_COMPILE_DEFINITIONS}
 
     $<$<CONFIG:DebugE>:_DEBUG>
     $<$<CONFIG:DebugE>:WWDEBUG>
     $<$<CONFIG:DebugE>:WIN32>
     $<$<CONFIG:DebugE>:PARAM_EDITING_ON>
-
-    $<$<CONFIG:Internal>:NDEBUG>
-    $<$<CONFIG:Internal>:_INTERNAL>
 
     $<$<CONFIG:Profile>:NDEBUG>
     $<$<CONFIG:Profile>:WWDEBUG>
@@ -47,22 +41,12 @@ target_compile_definitions(wwsaveload PRIVATE
     $<$<CONFIG:ProfileE>:WWDEBUG>
     $<$<CONFIG:ProfileE>:WIN32>
     $<$<CONFIG:ProfileE>:PARAM_EDITING_ON>
-
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Release>:WIN32>
-    $<$<CONFIG:Release>:IG_DEBUG_STACKTRACE>
 )
 
-#
-# --- Example: Match the different MSVC runtime libraries (/MDd vs /MD),
-#     optimization settings (/Od vs /O2), etc.
-#
-#     NOTE: In your .vcxproj:
-#       - Debug, DebugE => MultiThreadedDebugDLL => /MDd
-#       - Internal, Profile, ProfileE, Release => MultiThreadedDLL => /MD
-#       - DebugE, ProfileE => Optimization = Disabled => /Od
-#       - Debug => "MaxSpeed" => typically /O2, "InlineFunctionExpansion=AnySuitable" => /Ob2
-#       - Internal => "MaxSpeed", "OnlyExplicitInline" => /O2 /Ob1
-#       - Profile => "MaxSpeed", "AnySuitable" => /O2 /Ob2
-#       - Release => "MaxSpeed", "AnySuitable" => /O2 /Ob2
-#
+target_compile_options(wwsaveload PRIVATE
+    ${GNG_COMPILE_OPTIONS}
+)
+
+target_link_options(wwsaveload PRIVATE
+    ${GNG_LINK_OPTIONS}
+)

--- a/Code/Main/WinMain.cpp
+++ b/Code/Main/WinMain.cpp
@@ -66,6 +66,7 @@
 //#include "GeneratedVersion.h"
 #include "Resource.h"
 
+#include "../GameEngine/Source/Console/Console.h"
 #include "../gamerenderer/imgui/imgui.h"
 #include "../gamerenderer/imgui/imgui_impl_win32.h"
 #include "../gamerenderer/imgui/imgui_impl_dx9.h"
@@ -80,7 +81,6 @@
 HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Bool ApplicationIsWindowed = true;
-Bool IsConsoleActive = false;
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
 
@@ -502,7 +502,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 				switch( key )
 				{
 					case 192:
-						IsConsoleActive = !IsConsoleActive;
+						DevConsole.IsConsoleActive = !DevConsole.IsConsoleActive;
 						break;
 
 					//---------------------------------------------------------------------

--- a/Code/Tools/DebugWindow/CMakeLists.txt
+++ b/Code/Tools/DebugWindow/CMakeLists.txt
@@ -6,50 +6,20 @@ add_library(DebugWindow SHARED
     StdAfx.cpp           # Creates the PCH
 )
 
-#------------------------------------------------------------------------------
-# 1) MFC usage in a static library => we set MFC_FLAG=1
-#------------------------------------------------------------------------------
 set_property(TARGET DebugWindow PROPERTY MFC_FLAG 1)
 
 target_precompile_headers(DebugWindow PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:stdafx.h>
+    stdafx.h
 )
 
-#------------------------------------------------------------------------------
-# 3) We are using MFC statically, but the runtime library is also static
-#    (/MTd for Debug, /MT for Release). We also see "MultiByte" => define _MBCS.
-#------------------------------------------------------------------------------
 target_compile_definitions(DebugWindow PRIVATE
-  _MBCS
-  WIN32
-  _WINDOWS
-  _USRDLL
-
-  $<$<CONFIG:Debug>:_DEBUG>
-
-  $<$<CONFIG:Release>:NDEBUG>
+    ${GNG_COMPILE_DEFINITIONS}
 )
 
 target_compile_options(DebugWindow PRIVATE
-  $<$<C_COMPILER_ID:MSVC>:
-    # Debug
-    $<$<CONFIG:Debug>:
-      /Od           # Disabled optimization
-      /MTd          # Static runtime, debug
-      /Zi           # Debug info
-    >
-    # Release
-    $<$<CONFIG:Release>:
-      /O2           # MaxSpeed optimization
-      /Ob1          # "OnlyExplicitInline"
-      /MT           # Static runtime
-      /GF /Gy       # (Optional) string pooling & function-level linking
-    >
-  >
+    ${GNG_COMPILE_OPTIONS}
 )
 
 target_link_options(DebugWindow PRIVATE
-  /SUBSYSTEM:WINDOWS
-  /DYNAMICBASE:NO
-  /MAP
+    ${GNG_LINK_OPTIONS}
 )

--- a/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -132,47 +132,18 @@ target_include_directories(WorldBuilder PRIVATE
 )
 
 target_compile_definitions(WorldBuilder PRIVATE
+  ${GNG_COMPILE_DEFINITIONS}
   _AFXDLL
   _MBCS
-  __PLACEMENT_VEC_NEW_INLINE
   WIN32
-  _WINDOWS
   EDITOR
   REGEX_MALLOC
   STDC_HEADERS
   WIN32_LEAN_AND_MEAN
-
-  # Debug
-  $<$<CONFIG:Debug>:_DEBUG>
-
-  # Internal
-  $<$<CONFIG:Internal>:
-    _DISABLE_STRING_ANNOTATION
-    _DISABLE_VECTOR_ANNOTATION
-    NDEBUG
-    _INTERNAL
-  >
-
-  # Release
-  $<$<CONFIG:Release>:
-    _DISABLE_STRING_ANNOTATION
-    _DISABLE_VECTOR_ANNOTATION
-    IG_DEBUG_STACKTRACE
-    NDEBUG
-    _RELEASE
-  >
 )
 
-# Typical MSVC flags for each config:
 target_compile_options(WorldBuilder PRIVATE
-  $<$<C_COMPILER_ID:MSVC>:
-
-    $<$<CONFIG:Debug>:/Od /MDd /Zi /RTC1>
-
-    $<$<CONFIG:Internal>:/O2 /Ob1 /MD /Zi /GF /Gy>
-
-    $<$<CONFIG:Release>:/O2 /Ob2 /MD /GF /Gy>
-  >
+    ${GNG_COMPILE_OPTIONS}
 )
 
 target_link_libraries(WorldBuilder PRIVATE
@@ -191,17 +162,11 @@ target_link_libraries(WorldBuilder PRIVATE
     imm32
     wininet
 
-    # External Dependencies
-    OpenAL::OpenAL
-
-    # GameSpy SDK
-    UniSpySDK
-
     GameEngine
 )
 
 target_link_options(WorldBuilder PRIVATE
-  /NODEFAULTLIB:libcd /DYNAMICBASE:NO /FORCE
+    ${GNG_LINK_OPTIONS}
 )
 
 target_link_directories(WorldBuilder PRIVATE
@@ -216,7 +181,7 @@ set_target_properties(WorldBuilder PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/../../../run"
 
     # Each config has its own output name:
-    OUTPUT_NAME_DEBUG "WorldBuilder_debug"      # Debug
-    OUTPUT_NAME_INTERNAL "WorldBuilder_internal"   # Internal
-    OUTPUT_NAME_RELEASE "WorldBuilder"     # Release
+    OUTPUT_NAME_DEBUG "WorldBuilder_debug"
+    OUTPUT_NAME_INTERNAL "WorldBuilder_internal"
+    OUTPUT_NAME_RELEASE "WorldBuilder"
 )


### PR DESCRIPTION
Reduced Warning level to 1 for now

``/DYNAMICBASE:NO``,``/FORCE``, and ``/NODEFAULTLIB:libcd`` removed from WorldBuilder as they did not seem to fix anything

``/Ob1`` removed from Debug and Internal builds as it does not seem to matter and simplifies configs

``/Ob2`` removed from Release build as it is implied by /O2

``/GF`` removed from Release and Internal builds as it is implied by /O2

Enable ``/Gy`` (Function level linking) for all Release and Internal builds

``BROWSER_DEBUG`` and ``_LIB`` Definition removed as it did not seem to have any effect and never referenced in code

``_DISABLE_STRING_ANNOTATION`` and ``_DISABLE_VECTOR_ANNOTATION`` removed as they did have any effect on anything

Defined ``WINVER=0x0A00`` & ``_WIN32_WINNT=0x0A00`` globally (Windows 10 as a minimum because we use DX12)

``Z_PREFIX`` Definition removed as it seems to have no effect (meant for zlib, but defined for GameEngine, not even Compression)

This also fixes Internal build as it seemed broken after moving to CMake
