### PR TITLE
Reduce the number of file open failed errors

### DIFF
--- a/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -176,6 +176,12 @@ File*		FileSystem::openFile( const Char *filename, Int access )
 	USE_PERF_TIMER(FileSystem)
 	File *file = NULL;
 
+	if ( filename == AsciiString::TheEmptyString )
+	{
+		// DEBUG_LOG(("FileSystem::openFile() - Empty filename\n"));
+		return NULL; // no need to bother loading an empty filename
+	}
+
 	if ( TheLocalFileSystem != NULL )
 	{
 		file = TheLocalFileSystem->openFile( filename, access );
@@ -184,6 +190,11 @@ File*		FileSystem::openFile( const Char *filename, Int access )
 	if ( (TheArchiveFileSystem != NULL) && (file == NULL) )
 	{
 		file = TheArchiveFileSystem->openFile( filename );
+	}
+
+	if ( file == NULL )
+	{
+		DEBUG_LOG(("FileSystem::openFile() - Unable to open file '%s'\n", filename));
 	}
 
 	return file;

--- a/Code/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/Code/GameEngine/Source/Common/System/LocalFile.cpp
@@ -271,7 +271,7 @@ Bool LocalFile::open( const Char *filename, Int access )
 
 	if( m_handle == -1 )
 	{
-		DEBUG_LOG(("LocalFile::open FAILED %s (total %d)\n", filename, s_totalOpen));
+		// DEBUG_LOG(("LocalFile::open FAILED %s (total %d)\n", filename, s_totalOpen));
 		goto error;
 	}
 


### PR DESCRIPTION
In the game's current state, it first tries to open requested files from the main directory structure, and should it fail at that, it will try to open it from one of the .big files. However, this results in an avalanche of debug messages for nearly every requested file and is therefore unhelpful while debugging. This PR moves this failure message into the general `FileSystem::openFile` function which will make it more helpful.

Additionally, a check is added to find whether the file name is an empty string. If it is, there is no point to continue loading such a file.