### PR TITLE
Remove __PLACEMENT_VEC_NEW_INLINE Hack

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -41,7 +41,6 @@ if(MSVC)
         /NOLOGO # Hide linker copyright notice
     )
     set(GNG_COMPILE_DEFINITIONS
-        __PLACEMENT_VEC_NEW_INLINE # Hack for placement new overides (will be removed)
         _WINDOWS
         WINVER=0x0A00              # Windows 10 is the minimum as we use DX12
         _WIN32_WINNT=0x0A00        # Windows 10 is the minimum as we use DX12

--- a/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Code/GameEngine/Include/Common/GameMemory.h
@@ -760,11 +760,16 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	extern void* __cdecl operator new[](size_t nSize, const char *, int);
 	extern void __cdecl operator delete[](void *, const char *, int);
 
+	// We don't need placement new overloads as they do nothing speical
+	// instead we include the new header to provide it in case it was not already included.
+	// Andrew-2E128
+#include <new>
+
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }
-	inline void* __cdecl operator new[]						(size_t s, void *p) { return p; }
-	inline void __cdecl operator delete[]					(void *, void *p)		{ }
+	//inline void* __cdecl operator new[]						(size_t s, void *p) { return p; }
+	//inline void __cdecl operator delete[]					(void *, void *p)		{ }
 
 #endif
 

--- a/Code/GameEngine/Source/Precompiled/PreRTS.h
+++ b/Code/GameEngine/Source/Precompiled/PreRTS.h
@@ -41,7 +41,6 @@ class STLSpecialAlloc;
 // PLEASE DO NOT ABUSE WINDOWS OR IT WILL BE REMOVED ENTIRELY. :-)
 //--------------------------------------------------------------------------------- System Includes 
 
-//#define __PLACEMENT_VEC_NEW_INLINE // jmarshall
 #include <string.h>
 #include <atlbase.h>
 #include <windows.h>

--- a/Code/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Code/Libraries/Source/WWVegas/WWLib/always.h
@@ -88,11 +88,16 @@
 	extern void* __cdecl operator new[]		(size_t nSize, const char *, int);
 	extern void __cdecl operator delete[]	(void *, const char *, int);
 
+	// We don't need placement new overloads as they do nothing speical
+	// instead we include the new header to provide it in case it was not already included.
+	// Andrew-2E128
+#include <new>
+
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }
-	inline void* __cdecl operator new[]						(size_t s, void *p) { return p; }
-	inline void __cdecl operator delete[]					(void *, void *p)		{ }
+	//inline void* __cdecl operator new[]						(size_t s, void *p) { return p; }
+	//inline void __cdecl operator delete[]					(void *, void *p)		{ }
 
 #endif
 


### PR DESCRIPTION
Remove the need for __PLACEMENT_VEC_NEW_INLINE hack by including the <new> header as such functions don't even do anything different from standard, and are not allowed to be overridden