### PR TITLE
Don't repeat clipping code

### DIFF
--- a/Code/Main/WinMain.cpp
+++ b/Code/Main/WinMain.cpp
@@ -421,9 +421,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 
 				if (AllowMouseClip())
 				{
-					RECT rect;
-					GetClientRect(hWnd, &rect);
-					ClipCursor(&rect);
+					RestoreMouseClip();
 				}
 
 				break;
@@ -435,9 +433,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 				{
 					if(AllowMouseClip())
 					{
-						RECT rect;
-						GetClientRect(hWnd, &rect);
-						ClipCursor(&rect);
+						RestoreMouseClip();
 					}
 					
 					int width = LOWORD(lParam);
@@ -478,9 +474,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 
 				if (AllowMouseClip())
 				{
-					RECT rect;
-					GetClientRect(hWnd, &rect);
-					ClipCursor(&rect);
+					RestoreMouseClip();
 				}
 
 				if (isWinMainActive)


### PR DESCRIPTION
Just a tiny cleanup, if RestoreMouseClip() is there it should be used.