### PR TITLE
Pathfind fixes

### DIFF
--- a/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -219,7 +219,7 @@ protected:
 	PathfindCellInfo *m_pathParent;												///< "parent" cell from pathfinder
 	PathfindCell *m_cell;															///< Cell this info belongs to currently.
 
-	UnsignedShort m_totalCost, m_costSoFar;	///< cost estimates for A* search
+	UnsignedInt m_totalCost, m_costSoFar;	///< cost estimates for A* search
 
 	/// have to include cell's coordinates, since cells are often accessed via pointer only
 	ICoord2D m_pos;

--- a/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1083,8 +1083,8 @@ Real Path::computeFlightDistToGoal( const Coord3D *pos, Coord3D& goalPos )
 }
 //-----------------------------------------------------------------------------------
 
-enum { PATHFIND_CELLS_PER_FRAME=5000}; // Number of cells we will search pathfinding per frame.
-enum {CELL_INFOS_TO_ALLOCATE = 30000};
+enum { PATHFIND_CELLS_PER_FRAME=50000}; // Number of cells we will search pathfinding per frame.
+enum {CELL_INFOS_TO_ALLOCATE = 3000000};
 PathfindCellInfo *PathfindCellInfo::s_infoArray = NULL;
 PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;						
 /**
@@ -6131,7 +6131,13 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
 			return path;
-		}	
+		}
+
+		if (cellCount > 30000)
+		{
+			DEBUG_LOG(("Pathfind failed: cell count exceeded 30000\n"));
+			break;
+		}
 
 		// put parent cell onto closed list - its evaluation is finished
 		m_closedList = parentCell->putOnClosedList( m_closedList );

--- a/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
+++ b/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
@@ -69,7 +69,7 @@ protected:
 	static Int							m_numDebugIcons;
 
 protected:
-	enum {MAX_ICONS = 100000};
+	enum {MAX_ICONS = 500000};
 	void allocateIconsArray(void);
 	void compressIconsArray(void);
 


### PR DESCRIPTION
This pull request mitigates the issue where units wouldn't move if many units were selected simultaneously. It also fixes an issue where pathfinding would break completely if the cost exceeded 65,535. I've also added a pathfinding limit of 30,000 cells per unit. This limit exists in BFME1, but there it's only 15,000. Ideally, we would use a similar limit, but the hierarchical pathfinding is currently somewhat broken and requires fixing first.