### PR TITLE
Increase limit of D3D vertex/index buffers

### DIFF
--- a/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DBufferManager.h
+++ b/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DBufferManager.h
@@ -38,13 +38,13 @@
 #define MAX_VB_SIZES 128	//number of different sized VB slots allowed.
 #define MIN_SLOT_SIZE	32	//minimum number of vertices allocated per slot (power of 2). See also MIN_SLOT_SIZE_SHIFT.
 #define	MIN_SLOT_SIZE_SHIFT	5 //used for division by MIN_SLOT_SIZE
-#define MAX_VERTEX_BUFFERS_CREATED	32	//maximum number of D3D vertex buffers allowed to create per vertex type.
-#define DEFAULT_VERTEX_BUFFER_SIZE	8192	//this size ends up generating VB's of about 256Kbytes
-#define MAX_NUMBER_SLOTS	4096			//maximum number of slots that can be allocated.
+#define MAX_VERTEX_BUFFERS_CREATED	64	//maximum number of D3D vertex buffers allowed to create per vertex type.
+#define DEFAULT_VERTEX_BUFFER_SIZE	16384	//this size ends up generating VB's of about 512Kbytes
+#define MAX_NUMBER_SLOTS	262144			//maximum number of slots that can be allocated.
 
 #define MAX_IB_SIZES 128 //number of different sized IB slots allowed (goes all the way up to 65536)
-#define MAX_INDEX_BUFFERS_CREATED	32
-#define DEFAULT_INDEX_BUFFER_SIZE	32768	
+#define MAX_INDEX_BUFFERS_CREATED	64
+#define DEFAULT_INDEX_BUFFER_SIZE	49152	
 
 class W3DBufferManager
 {

--- a/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2830,7 +2830,7 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 
 	DEBUG_ASSERTCRASH(vbSlot != NULL, ("Can't allocate vertex buffer slot for shadow volume"));
 
-	DEBUG_ASSERTCRASH(vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
+	DEBUG_ASSERTCRASH(vbSlot == NULL || vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
 
 	DEBUG_ASSERTCRASH(m_shadowVolume[ volumeIndex ][meshIndex]->GetNumPolygon() == 0,("Updating Existing Static Shadow Volume"));
 
@@ -2839,7 +2839,7 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 
 	DEBUG_ASSERTCRASH(ibSlot != NULL, ("Can't allocate index buffer slot for shadow volume"));
 
-	DEBUG_ASSERTCRASH(ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
+	DEBUG_ASSERTCRASH(ibSlot == NULL || ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
 
 	if (!ibSlot || !vbSlot)
 	{	//could not allocate storage to hold buffers


### PR DESCRIPTION
This pull request fixes a crash that would occur when many units were on the screen by increasing the vertex/index buffer limit of the game. As far as it has been tested, it no longer crashes when units are created all over the map, but I'm pretty sure this fix is not ideal, and maybe it should be made more dynamic in the future.