### PR TITLE
Fix RegistryClass assert

### DIFF
--- a/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
+++ b/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
@@ -124,7 +124,7 @@ int LCW_Uncomp(void const * source, void * dest, unsigned long )
 					word_data  = (word_data << 24) + (word_data << 16) + (word_data << 8) + word_data;
 					source_ptr += 3;
 
-					copy_ptr = dest_ptr + 4 - ((unsigned) dest_ptr & 0x3);
+					copy_ptr = dest_ptr + 4 - ((uintptr_t) dest_ptr & 0x3);
 					count -= (copy_ptr - dest_ptr);
 					while (dest_ptr < copy_ptr) *dest_ptr++ = data;
 

--- a/Code/Libraries/Source/WWVegas/WWLib/registry.cpp
+++ b/Code/Libraries/Source/WWVegas/WWLib/registry.cpp
@@ -47,12 +47,12 @@ RegistryClass::RegistryClass( const char * sub_key ) :
 {
 	DWORD disposition;
 	HKEY	key;
-	assert( sizeof(HKEY) == sizeof(int) );
+	assert( sizeof(HKEY) == sizeof(intptr_t) );
 	if (::RegCreateKeyEx( HKEY_LOCAL_MACHINE, sub_key,
 			0, NULL, 0, KEY_ALL_ACCESS, NULL,
 			&key, &disposition ) == ERROR_SUCCESS) {
 		IsValid = true;
-		Key = (int)key;
+		Key = (intptr_t)key;
 	}
 }
 

--- a/Code/Libraries/Source/WWVegas/WWLib/registry.h
+++ b/Code/Libraries/Source/WWVegas/WWLib/registry.h
@@ -94,7 +94,7 @@ public:
 	void	Deleta_All_Values( void );
 
 private:
-	int	Key;
+	intptr_t	Key;
 	bool	IsValid;
 };
 


### PR DESCRIPTION
This pull request fixes an assertion that was comparing the size of an HKEY to an int. This is incorrect on x64, since HKEY is the size of an int64 on x64.